### PR TITLE
Support different sizes of the images

### DIFF
--- a/src/App/Api/Photo.cs
+++ b/src/App/Api/Photo.cs
@@ -3,5 +3,7 @@
     public class Photo
     {
         public string Small { get; set; }
+        public string Medium { get; set; }        
+        public string Large { get; set; }        
     }
 }


### PR DESCRIPTION
It used to support only only small. Now added medium and large. That would allow better to adjust pets picture on the Friends page. 

#6 